### PR TITLE
[3/4] Deprecate log_gpu_memory, gpu_metrics, and util funcs

### DIFF
--- a/pytorch_lightning/callbacks/__init__.py
+++ b/pytorch_lightning/callbacks/__init__.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pytorch_lightning.callbacks.base import Callback
+from pytorch_lightning.callbacks.device_stats_monitor import DeviceStatsMonitor
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks.finetuning import BackboneFinetuning, BaseFinetuning
 from pytorch_lightning.callbacks.gpu_stats_monitor import GPUStatsMonitor
 from pytorch_lightning.callbacks.gradient_accumulation_scheduler import GradientAccumulationScheduler
 from pytorch_lightning.callbacks.lambda_function import LambdaCallback
 from pytorch_lightning.callbacks.lr_monitor import LearningRateMonitor
-from pytorch_lightning.callbacks.device_stats_monitor import DeviceStatsMonitor
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.callbacks.model_summary import ModelSummary
 from pytorch_lightning.callbacks.prediction_writer import BasePredictionWriter

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -29,6 +29,11 @@ from pytorch_lightning.utilities.warnings import rank_zero_deprecation
 class LoggerConnector:
     def __init__(self, trainer: "pl.Trainer", log_gpu_memory: Optional[str] = None) -> None:
         self.trainer = trainer
+        if log_gpu_memory is not None:
+            rank_zero_deprecation(
+                "Setting `log_gpu_memory` with the trainer flag is deprecated and will be removed in v1.7. "
+                "Please monitor GPU stats with the `DeviceStatsMonitor` callback directly instead."
+            )
         self.log_gpu_memory = log_gpu_memory
         self.eval_loop_results: List[_OUT_DICT] = []
         self._val_log_step: int = 0
@@ -220,7 +225,7 @@ class LoggerConnector:
     def update_train_step_metrics(self) -> None:
         if self.trainer.fit_loop._should_accumulate() and self.trainer.lightning_module.automatic_optimization:
             return
-
+        # TODO: remove this call in v1.7
         self._log_gpus_metrics()
 
         # when metrics should be logged
@@ -238,6 +243,11 @@ class LoggerConnector:
         self.trainer._results.reset(metrics=True)
 
     def _log_gpus_metrics(self) -> None:
+        """
+        .. deprecated:: v1.5
+            This function was deprecated in v1.5 in favor of
+            `pytorch_lightning.accelerators.gpu._get_nvidia_gpu_stats` and will be removed in v1.7.
+        """
         for key, mem in self.gpus_metrics.items():
             if self.log_gpu_memory == "min_max":
                 self.trainer.lightning_module.log(key, mem, prog_bar=False, logger=True)
@@ -307,6 +317,14 @@ class LoggerConnector:
 
     @property
     def gpus_metrics(self) -> Dict[str, float]:
+        """
+        .. deprecated:: v1.5
+            Will be removed in v1.7.
+        """
+        rank_zero_deprecation(
+            "The property `LoggerConnector.gpus_metrics` was deprecated in v1.5"
+            " and will be removed in 1.7. Use the DeviceStatsMonitor callbacks instead."
+        )
         if self.trainer._device_type == DeviceType.GPU and self.log_gpu_memory:
             mem_map = memory.get_memory_profile(self.log_gpu_memory)
             self._gpus_metrics.update(mem_map)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -113,7 +113,7 @@ class Trainer(
         auto_select_gpus: bool = False,
         tpu_cores: Optional[Union[List[int], str, int]] = None,
         ipus: Optional[int] = None,
-        log_gpu_memory: Optional[str] = None,
+        log_gpu_memory: Optional[str] = None,  # TODO: Remove in 1.7
         progress_bar_refresh_rate: Optional[int] = None,
         overfit_batches: Union[int, float] = 0.0,
         track_grad_norm: Union[int, float, str] = -1,
@@ -240,6 +240,10 @@ class Trainer(
                 of the individual loggers.
 
             log_gpu_memory: None, 'min_max', 'all'. Might slow performance.
+
+                .. deprecated:: v1.5
+                    Deprecated in v1.5.0 and will be removed in v1.7.0
+                    Please use the ``DeviceStatsMonitor`` callback directly instead.
 
             log_every_n_steps: How often to log within steps (defaults to every 50 steps).
 

--- a/pytorch_lightning/utilities/memory.py
+++ b/pytorch_lightning/utilities/memory.py
@@ -96,7 +96,12 @@ def garbage_collection_cuda() -> None:
 
 
 def get_memory_profile(mode: str) -> Dict[str, float]:
-    """Get a profile of the current memory usage.
+    """
+    .. deprecated:: v1.5
+            This function was deprecated in v1.5 in favor of
+            `pytorch_lightning.accelerators.gpu._get_nvidia_gpu_stats` and will be removed in v1.7.
+
+    Get a profile of the current memory usage.
 
     Args:
         mode: There are two modes:
@@ -124,7 +129,12 @@ def get_memory_profile(mode: str) -> Dict[str, float]:
 
 
 def get_gpu_memory_map() -> Dict[str, float]:
-    """Get the current gpu usage.
+    """
+    .. deprecated:: v1.5
+            This function was deprecated in v1.5 in favor of
+            `pytorch_lightning.accelerators.gpu._get_nvidia_gpu_stats` and will be removed in v1.7.
+
+    Get the current gpu usage.
 
     Return:
         A dictionary in which the keys are device ids as integers and

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -19,6 +19,7 @@ import torch
 
 from pytorch_lightning import Callback, LightningDataModule, Trainer
 from pytorch_lightning.loggers import TestTubeLogger
+from pytorch_lightning.trainer.connectors.logger_connector import LoggerConnector
 from tests.deprecated_api import _soft_unimport_module
 from tests.helpers import BoringModel
 from tests.helpers.datamodules import MNISTDataModule
@@ -224,3 +225,13 @@ def test_v1_7_0_deprecate_add_get_queue(tmpdir):
 
     with pytest.deprecated_call(match=r"`LightningModule.get_from_queue` method was deprecated in v1.5"):
         trainer.fit(model)
+
+
+def test_v1_7_0_trainer_log_gpu_memory(tmpdir):
+    with pytest.deprecated_call(
+        match="Setting `log_gpu_memory` with the trainer flag is deprecated and will be removed in v1.7."
+    ):
+        trainer = Trainer(log_gpu_memory="min_max")
+    with pytest.deprecated_call(match="The property `LoggerConnector.gpus_metrics` was deprecated in v1.5"):
+        lg = LoggerConnector(trainer)
+        _ = lg.gpus_metrics


### PR DESCRIPTION
## What does this PR do?
Deprecate `log_gpu_memory` from Trainer constructor, deprecate `gpu_metrics` from LoggerConnector, and deprecate some util functions from `utilities/memory.py`.

These will all be replaced by the DeviceStatsCallback which calls `get_device_stats` on the Accelerator interface

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/9032

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
